### PR TITLE
Declare dependency on emacs 24

### DIFF
--- a/easy-kill.el
+++ b/easy-kill.el
@@ -4,6 +4,7 @@
 
 ;; Author: Leo Liu <sdl.web@gmail.com>
 ;; Version: 0.7.0
+;; Package-Requires: ((emacs "24"))
 ;; Keywords: convenience
 ;; Created: 2013-08-12
 ;; URL: https://github.com/leoliu/easy-kill


### PR DESCRIPTION
The code declares `lexical-binding: t`, which is only available in Emacs 24.

If the code doesn't actually need that setting, I'd suggest removing it instead, and not merging this pull request.

(This is in connection with https://github.com/milkypostman/melpa/pull/1081)
