### PR TITLE
[remap kill-ring-save] should be a better key binding for this feature.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ To Use
 ::
 
    (require 'easy-kill)
-   (global-set-key "\M-w" 'easy-kill)
+   (global-set-key [remap kill-ring-save] 'easy-kill)
 
 Extensions
 ~~~~~~~~~~

--- a/easy-kill.el
+++ b/easy-kill.el
@@ -25,7 +25,7 @@
 
 ;; `easy-kill' aims to be a drop-in replacement for `kill-ring-save'.
 ;;
-;; To use: (global-set-key "\M-w" 'easy-kill)
+;; To use: (global-set-key [remap kill-ring-save] 'easy-kill)
 
 ;;; Code:
 


### PR DESCRIPTION
Otherwise, you cannot properly copy a selected region in such extended
selection modes as CUA/CUA rectangle.
