### PR TITLE
Implement easy-kill-delete-region.

### DIFF
--- a/easy-kill.el
+++ b/easy-kill.el
@@ -122,6 +122,7 @@ deprecated."
     (define-key map "?" 'easy-kill-help)
     (define-key map [remap set-mark-command] 'easy-kill-mark-region)
     (define-key map [remap kill-region] 'easy-kill-region)
+    (define-key map [remap delete-region] 'easy-kill-delete-region)
     (define-key map [remap keyboard-quit] 'easy-kill-abort)
     (define-key map [remap exchange-point-and-mark]
       'easy-kill-exchange-point-and-mark)
@@ -530,6 +531,12 @@ checked."
     (easy-kill-interprogram-cut (car kill-ring))
     (setq deactivate-mark t)
     (easy-kill-echo "Appended")))
+
+(put 'easy-kill-delete-region 'easy-kill-exit t)
+(defun easy-kill-delete-region ()
+  (interactive)
+  (pcase (easy-kill-get bounds)
+    (`(,beg . ,end) (delete-region beg end))))
 
 (put 'easy-kill-unhighlight 'easy-kill-exit t)
 (defun easy-kill-unhighlight ()

--- a/test.el
+++ b/test.el
@@ -82,6 +82,18 @@
     (call-interactively #'easy-kill-append)
     (should (string= (car kill-ring) "abc"))))
 
+(ert-deftest test-easy-kill-delete-region ()
+  (with-temp-buffer
+    (insert "abc def ghi")
+    (backward-word 2)
+    (kill-new "test")
+    (easy-kill)
+    (easy-kill-thing 'word)
+    (call-interactively #'easy-kill-delete-region)
+    (should (string= (car kill-ring) "test"))
+    (should (string= (buffer-substring-no-properties (point-min) (point)) "abc "))
+    (should (string= (buffer-substring-no-properties (point) (point-max)) " ghi"))))
+
 ;;; Make sure the old format of easy-kill-alist is still supported.
 (ert-deftest test-old-easy-kill-alist ()
   (let ((easy-kill-alist '((?w . word)


### PR DESCRIPTION
This may also be bound to [delete]/[backspace] in easy-kill-base-map as per user's preference.