### PR TITLE
Make easy-kill work nicely with multiple-cursors

### DIFF
--- a/easy-kill.el
+++ b/easy-kill.el
@@ -226,6 +226,9 @@ The value is the function's symbol if non-nil."
 
 (defvar easy-kill-candidate nil)
 
+(with-eval-after-load 'multiple-cursors
+  (add-to-list 'mc/cursor-specific-vars 'easy-kill-candidate))
+
 (defun easy-kill--bounds ()
   (cons (overlay-start easy-kill-candidate)
         (overlay-end easy-kill-candidate)))

--- a/easy-kill.el
+++ b/easy-kill.el
@@ -863,6 +863,14 @@ inspected."
 (with-eval-after-load 'multiple-cursors
   (add-to-list 'mc/cursor-specific-vars 'easy-kill-candidate)
 
+  (defadvice easy-kill-destroy-candidate
+    (around multiple-cursors-support activate)
+    (if (bound-and-true-p multiple-cursors-mode)
+        (mc/for-each-cursor-ordered
+         (mc/restore-state-from-overlay cursor)
+         ad-do-it)
+      ad-do-it))
+
   (dolist (func '(easy-kill-help))
     (add-to-list 'mc/cmds-to-run-once func))
   (dolist (func '(easy-kill

--- a/easy-kill.el
+++ b/easy-kill.el
@@ -226,9 +226,6 @@ The value is the function's symbol if non-nil."
 
 (defvar easy-kill-candidate nil)
 
-(with-eval-after-load 'multiple-cursors
-  (add-to-list 'mc/cursor-specific-vars 'easy-kill-candidate))
-
 (defun easy-kill--bounds ()
   (cons (overlay-start easy-kill-candidate)
         (overlay-end easy-kill-candidate)))
@@ -862,6 +859,25 @@ inspected."
           (lambda ()
             (format "%s (%s)" (easy-kill-get thing) (js2-node-short-name node))))
     (easy-kill-echo "%s" (js2-node-short-name node))))
+
+(with-eval-after-load 'multiple-cursors
+  (add-to-list 'mc/cursor-specific-vars 'easy-kill-candidate)
+
+  (dolist (func '(easy-kill-help))
+    (add-to-list 'mc/cmds-to-run-once func))
+  (dolist (func '(easy-kill
+                  easy-kill-abort
+                  easy-kill-append
+                  easy-kill-delete-region
+                  easy-kill-digit-argument
+                  easy-kill-expand
+                  easy-kill-mark-region
+                  easy-kill-region
+                  easy-kill-shrink
+                  easy-kill-thing
+                  easy-kill-unhighlight
+                  easy-mark))
+    (add-to-list 'mc/cmds-to-run-for-all func)))
 
 (provide 'easy-kill)
 ;;; easy-kill.el ends here


### PR DESCRIPTION
By marking the variable `easy-kill-candidate` as a cursor specific variable, easy-kill/easy-mark functions work nicely with [multiple-cursors](https://github.com/magnars/multiple-cursors.el).