### PR TITLE
Exchange point and mark when set-mark-command.

### DIFF
--- a/easy-kill.el
+++ b/easy-kill.el
@@ -556,8 +556,8 @@ checked."
      (pcase (if (eq (easy-kill-get mark) 'end)
                 (list end beg) (list beg end))
        (`(,m ,pt)
-        (set-mark m)
-        (goto-char pt)))
+        (set-mark pt)
+        (goto-char m)))
      (activate-mark))))
 
 (defun easy-kill-exchange-point-and-mark ()


### PR DESCRIPTION
When the selection is turned into an active region, `point > mark` is assumed in current version. For example when a defun is selected, `point` is `end-of-defun`. But the built-in functions `mark-defun` places `point` to `beginning-of-defun`. The other `mark-*` command behaves in a similar way. This commit makes `easy-kill` to be consistent with the built-in commands.